### PR TITLE
Warn user and exit if unzip is not installed.

### DIFF
--- a/01-nli/get_datasets.sh
+++ b/01-nli/get_datasets.sh
@@ -12,6 +12,10 @@ ZIPTOOL="unzip"
 #    ZIPTOOL="7za x"
 #fi
 
+if ! type $ZIPTOOL > /dev/null; then
+  echo "unzip must be installed. Please run 'apt-get install unzip' and try again."
+  exit 1
+fi
 
 ### download SNLI
 echo "Downloading SNLI dataset..."


### PR DESCRIPTION
The split was mysteriously failing for me because I didn't have unzip installed. A warning such as this would have saved me a few minutes.